### PR TITLE
Refactor dirtify

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ You'll need to populate the raw folder with a bunch of source images. In our ini
 ##### dirtify
 To experiment with the Cleanify project, set your working directory to the source folder and run the dirtify tool. Then run the cleanify tool. Here are some examples:
 
+`dirtify --tile --blur 15` (separates source images into tiles, then does a 15-pixel Gaussian blur)</br>  
 `dirtify --jpeg 50` (compresses with JPEG at 50% quality, then decompresses)</br>
 `dirtify --blur 5` (performs a Gaussian blur with a 5-pixel radius)</br>
 `dirtify --noise 25` (renders 25% uniform noise on image)</br>

--- a/README.md
+++ b/README.md
@@ -3,16 +3,8 @@
 ### Intro
 This project comprises two tools: The `dirtify` Python tool takes a bunch of images and grabs small square thumbnails of them, then performs some sort of dirty filter on them, from a list of options. The `cleanify` tool uses a deep convolutional neural network to try to learn to convert dirty images to clean images.
 ### Dataset
-The required folder and dataset structure are:
-<pre>
-├───source
-│   cleanify.py
-│   dirtify.py
-└───input
-    └───raw
-</pre>
-
-You'll need to populate the raw folder with a bunch of source images. In our initial experiments, we used the Sharp subset of the [Blur dataset](https://www.kaggle.com/kwentar/blur-dataset "Blur dataset").
+In the same folder as the Python source files, you should have an "input" directory, containing a "raw" directory. In that raw directory should be a bunch of images.
+In our initial experiments, we used the Sharp subset of the [Blur dataset](https://www.kaggle.com/kwentar/blur-dataset "Blur dataset"). You can just put those image files into the raw folder.
 
 ##### dirtify
 To experiment with the Cleanify project, set your working directory to the source folder and run the dirtify tool. Then run the cleanify tool. Here are some examples:
@@ -23,15 +15,17 @@ To experiment with the Cleanify project, set your working directory to the sourc
 `dirtify --noise 25` (renders 25% uniform noise on image)</br>
 `dirtify --invert` (inverts the pixels)</br>
 `dirtify --xout` (draws a dark red 1-pixel-wide "X" through the image)</br>
-`dirtify -j 80 -b 3 -i -x` (Does a little of everything)</br>
+`dirtify -j 80 -b 3 -n 10 -i -x` (Does a little of everything)</br>
 
 The `dirtify` process will create new sibling folders beside raw:
 
 <pre>
-└───input
-    ├───raw
-    ├───clean
-    └───dirty
+├───cleanify.py
+├───dirtify.py
+└─┬─input
+  ├───raw
+  ├───clean
+  └───dirty
 </pre>
 
 ##### cleanify
@@ -41,16 +35,14 @@ The `dirtify` process will create new sibling folders beside raw:
 
 The results will appear in a new output folder.
 <pre>
-├───source
-│   cleanify.py
-│   dirtify.py
-├───input
-│   ├───raw
-│   ├───clean
-│   └───dirty
-└───output
-    └───saved_images
-</pre>
+├───cleanify.py
+├───dirtify.py
+├─┬─input
+│ ├───raw
+│ ├───clean
+│ └───dirty
+└─┬─output
+  └───saved_images</pre>
 
 ### History
 This project was derived from Sovit Ranjan Rath's tutorial, [Image Deblurring using Convolutional Neural Networks and Deep Learning](https://debuggercafe.com/image-deblurring-using-convolutional-neural-networks-and-deep-learning "Tutorial") and his original [GitHub repository](https://github.com/sovit-123/image-deblurring-using-deep-learning "Repo").

--- a/cleanify.py
+++ b/cleanify.py
@@ -27,8 +27,8 @@ parser.add_argument("-a", "--autoencoder", action="store_true",
 args = vars(parser.parse_args())
 
 # Make strings for directories
-input_dir  = '../input'
-output_dir = '../output'
+input_dir  = 'input'
+output_dir = 'output'
 image_dir  = output_dir + '/saved_images'
 
 # Make the image directory, if it already exists no FileExistsError will be raised
@@ -268,8 +268,8 @@ def validate(model, dataloader, epoch):
             # If finishing the first epoch save the clean and dirty image
             # for example: output/saved_images/clean<epoch#>.png
             if epoch == 0 and i == int((len(val_data)/dataloader.batch_size)-1):
-                save_image(clean_image.cpu().data, f"{image_dir}/clean{epoch}.png")
-                save_image(dirty_image.cpu().data, f"{image_dir}/dirty{epoch}.png")
+                save_image(clean_image.cpu().data, f"{image_dir}/clean.png")
+                save_image(dirty_image.cpu().data, f"{image_dir}/dirty.png")
             
             # Save the last clean and dirty image pair into outputs directory at the end of each epoch
             if i == int((len(val_data)/dataloader.batch_size)-1):
@@ -317,8 +317,8 @@ plt.plot(val_loss, color='red', label='validation loss')
 plt.xlabel('Epochs')
 plt.ylabel('Loss')
 plt.legend()
-plt.savefig('../output/loss.png')
+plt.savefig('output/loss.png')
 plt.show()
 # save the model to disk
 print('Saving model...')
-torch.save(model.state_dict(), '../output/model.pth')
+torch.save(model.state_dict(), 'output/model.pth')

--- a/dirtify.py
+++ b/dirtify.py
@@ -45,19 +45,19 @@ if abort:
     sys.exit()
 
 # Directories
-# Given a bunch of larger images in the ../input/raw:
+# Given a bunch of larger images in the input/raw:
 # (1) scale and crop to a small, square, manageable thumbnail size
-# (2) save that into ../input/clean
+# (2) save that into input/clean
 # (3) add the requested perturbation
-# (4) save that into ../input/dirty
+# (4) save that into input/dirty
 
-os.makedirs('../input/dirty', exist_ok=True)
-os.makedirs('../input/clean', exist_ok=True)
-raw_dir = '../input/raw'
-clean_dir = '../input/clean'
-dirty_dir = '../input/dirty'
+os.makedirs('input/dirty', exist_ok=True)
+os.makedirs('input/clean', exist_ok=True)
+raw_dir = 'input/raw'
+clean_dir = 'input/clean'
+dirty_dir = 'input/dirty'
 
-# Iterate through files in ../input/raw
+# Iterate through files in input/raw
 images = os.listdir(raw_dir)
 if '.DS_Store' in images:
     images.remove('.DS_Store') # For macOS: Skip invisible Desktop Services Store file.
@@ -135,8 +135,8 @@ for i, clean in tqdm(enumerate(images), total=len(images)):
     in_w = clean.shape[1]
     
     if args.tile:
-        raw_tile_h = 256
-        raw_tile_w = 256
+        raw_tile_h = 512
+        raw_tile_w = 512
         for y in range(int(in_h / raw_tile_h)):
             top = y * raw_tile_h
             bottom = top + raw_tile_h

--- a/dirtify.py
+++ b/dirtify.py
@@ -12,6 +12,8 @@ out_h = 64
 
 # construct the argument parser
 parser = argparse.ArgumentParser(description = "Filter a clean image, output a dirty one")
+parser.add_argument("-t", "--tile", action="store_true",
+                    help="use tiles to produce multiple subimages (as opposed to scaling once)")
 parser.add_argument("-j", "--jpeg", type=int,
                     help="JPEG-compress with quality (0-100%) and decompress")
 parser.add_argument("-b", "--blur", type=int,
@@ -60,41 +62,22 @@ images = os.listdir(raw_dir)
 if '.DS_Store' in images:
     images.remove('.DS_Store') # For macOS: Skip invisible Desktop Services Store file.
 
-for i, img in tqdm(enumerate(images), total=len(images)):
-    filename = f"{raw_dir}/{images[i]}"
-    img = cv2.imread(filename, cv2.IMREAD_COLOR)
-    
-    # resize and crop to make a 64 x 64 image
-    in_h = img.shape[0]
-    in_w = img.shape[1]
-    scale = max(out_h / in_h, out_w / in_w)
+# Dirtify function
+def add_dirt(in_img, w, h):
 
-    # resize...
-    img = cv2.resize(img, None, fx = scale, fy = scale, interpolation = cv2.INTER_AREA)
-    mid_h = scale * in_h / 2
-    mid_w = scale * in_w / 2
-
-    # ...and crop
-    img = img[round(mid_h - out_h/2):round(mid_h + out_h/2), round(mid_w - out_w/2):round(mid_w + out_w/2)]
-    out_name = os.path.splitext(images[i])[0] + ".png" # Change the extension to png (for lossless image)
-    cv2.imwrite(f"{clean_dir}/{out_name}", img)
-
-    # Add that dirt!
-    dirty = img
-    
     if args.invert:
         # Invert the image
-        dirty = 255 - dirty
+        img = 255 - in_img
 
     if args.jpeg is not None:
         # Compress with JPEG at given quality, then uncompress
         encode_param = [int(cv2.IMWRITE_JPEG_QUALITY), args.jpeg]
-        result, jpeg_bytes = cv2.imencode('.jpg', dirty, encode_param)
-        dirty = cv2.imdecode(jpeg_bytes, cv2.IMREAD_COLOR)
+        result, jpeg_bytes = cv2.imencode('.jpg', in_img, encode_param)
+        img = cv2.imdecode(jpeg_bytes, cv2.IMREAD_COLOR)
 
     if args.noise is not None:
         # Mix 3 channels of simple noise over the image
-        h, w, d = dirty.shape[0], dirty.shape[1], dirty.shape[2]
+        h, w, d = in_img.shape[0], in_img.shape[1], in_img.shape[2]
         noise_img = np.random.rand(h,w,d) * 255
         mask_img = np.random.rand(h,w,d)
         for y in range(h):
@@ -104,37 +87,90 @@ for i, img in tqdm(enumerate(images), total=len(images)):
                         alpha = mask_img[y,x,c] * (args.noise / 100.0) # Linear up to 100%
                     else:
                         alpha = mask_img[y,x,c] ** (100.0 / args.noise) # Curved above 100%
-                    dirty[y,x,c] = alpha * noise_img[y,x,c] + (1 - alpha) * dirty[y,x,c]
+                    img[y,x,c] = alpha * noise_img[y,x,c] + (1 - alpha) * in_img[y,x,c]
         
     if args.blur is not None:
         # Apply Gaussian Blur with given pixel radius
-        dirty = cv2.GaussianBlur(dirty, (args.blur, args.blur), 0)
+        img = cv2.GaussianBlur(in_img, (args.blur, args.blur), 0)
         
     if args.rblur is not None:
+        # Apply a radial blur
         radius = 0.01
-
-        growMapx = np.abs(np.tile(np.arange(out_h) + ((np.arange(out_h) - mid_w) * radius), (out_w, 1)).astype(np.float32))
-        shrinkMapx = np.abs(np.tile(np.arange(out_h) - ((np.arange(out_h) - mid_w) * radius), (out_w, 1)).astype(np.float32))
-        growMapy = np.abs(np.tile(np.arange(out_w) + ((np.arange(out_w) - mid_h) * radius), (out_h, 1)).transpose().astype(np.float32))
-        shrinkMapy = np.abs(np.tile(np.arange(out_w) - ((np.arange(out_w) - mid_h) * radius), (out_h, 1)).transpose().astype(np.float32))
+        mid_y = h / 2
+        mid_x = w / 2
+        growMapx = np.abs(np.tile(np.arange(h) + ((np.arange(h) - mid_x) * radius), (w, 1)).astype(np.float32))
+        shrinkMapx = np.abs(np.tile(np.arange(h) - ((np.arange(h) - mid_x) * radius), (w, 1)).astype(np.float32))
+        growMapy = np.abs(np.tile(np.arange(w) + ((np.arange(w) - mid_y) * radius), (h, 1)).transpose().astype(np.float32))
+        shrinkMapy = np.abs(np.tile(np.arange(w) - ((np.arange(w) - mid_y) * radius), (h, 1)).transpose().astype(np.float32))
         
         for i in range(args.rblur):
-            tmp1 = cv2.remap(dirty, growMapx, growMapy, cv2.INTER_LINEAR, borderMode=cv2.BORDER_REFLECT)
-            tmp2 = cv2.remap(dirty, shrinkMapx, shrinkMapy, cv2.INTER_LINEAR, borderMode=cv2.BORDER_REFLECT)
-            dirty = cv2.addWeighted(tmp1, 0.5, tmp2, 0.5, 0)
+            tmp1 = cv2.remap(in_img, growMapx, growMapy, cv2.INTER_LINEAR, borderMode=cv2.BORDER_REFLECT)
+            tmp2 = cv2.remap(in_img, shrinkMapx, shrinkMapy, cv2.INTER_LINEAR, borderMode=cv2.BORDER_REFLECT)
+            img = cv2.addWeighted(tmp1, 0.5, tmp2, 0.5, 0)
     
     if args.plus:
         # superimpose a white plus at a random position
-        x = round(random.random() * out_w)
-        y = round(random.random() * out_h)
-        cv2.line(dirty, (0,y), (out_w, y), (255,255,255), 1)
-        cv2.line(dirty, (x,0), (x, out_h), (255,255,255), 1)
+        x = round(random.random() * w)
+        y = round(random.random() * h)
+        img = in_img # make a copy so we don't overdraw the clean image
+        cv2.line(img, (0,y), (w, y), (255,255,255), 1)
+        cv2.line(img, (x,0), (x, h), (255,255,255), 1)
     
     if args.xout:
         # Draw a dark red X through the image
-        cv2.line(dirty, (0,0    ), (out_w,out_h), (0,0,64), 2)
-        cv2.line(dirty, (0,out_h), (out_w,0    ), (0,0,64), 2)
+        img = in_img # make a copy so we don't overdraw the clean image
+        cv2.line(img, (0,0), (w,h), (0,0,64), 2)
+        cv2.line(img, (0,h), (w,0), (0,0,64), 2)
     
-    cv2.imwrite(f"{dirty_dir}/{out_name}", dirty)
+    return img
+
+
+# Step through images
+for i, clean in tqdm(enumerate(images), total=len(images)):
+    filename = f"{raw_dir}/{images[i]}"
+    clean = cv2.imread(filename, cv2.IMREAD_COLOR)
+    
+    # resize and crop to make a 64 x 64 image
+    in_h = clean.shape[0]
+    in_w = clean.shape[1]
+    
+    if args.tile:
+        raw_tile_h = 256
+        raw_tile_w = 256
+        for y in range(int(in_h / raw_tile_h)):
+            top = y * raw_tile_h
+            bottom = top + raw_tile_h
+            for x in range(int(in_w / raw_tile_w)):
+                left = x * raw_tile_w
+                right = left + raw_tile_w
+                tile = clean[top:bottom, left:right]
+                
+                # Scale from raw tile size to output size
+                scale = out_h / raw_tile_h
+                tile = cv2.resize(tile, None, fx = scale, fy = scale, interpolation = cv2.INTER_AREA)
+
+                # Add that dirt!
+                dirty = add_dirt(tile, out_w, out_h)
+                
+                # And save files
+                out_name = os.path.splitext(images[i])[0] + f" ({x},{y}).png" # Change the extension to png (for lossless image)
+                cv2.imwrite(f"{clean_dir}/{out_name}", tile)
+                cv2.imwrite(f"{dirty_dir}/{out_name}", dirty)
+
+    else:
+        scale = max(out_h / in_h, out_w / in_w)
+
+        # resize and crop
+        mid_y = scale * in_h / 2
+        mid_x = scale * in_w / 2
+        clean = cv2.resize(clean, None, fx = scale, fy = scale, interpolation = cv2.INTER_AREA)
+        clean = clean[round(mid_y - out_h/2):round(mid_y + out_h/2), round(mid_x - out_w/2):round(mid_x + out_w/2)]
+
+        # Add that dirt!
+        dirty = add_dirt(clean, out_w, out_h)
+        
+        out_name = os.path.splitext(images[i])[0] + ".png" # Change the extension to png (for lossless image)
+        cv2.imwrite(f"{clean_dir}/{out_name}", clean)
+        cv2.imwrite(f"{dirty_dir}/{out_name}", dirty)
     
 print('DONE')


### PR DESCRIPTION
• Moved input and output directories into the same directory as our code. (They're in the .gitignore so the folders themselves won't move, but the references to the folders now point to the right place.)
• (Mostly nonfunctional refactoring) Refactor the dirtify function so it's not a monolithic beast.
• Add an optional --tile argument to dirtify to tile each 1536x2048 image into 6x8 256x256 images, each scaled down to 64x64.
• Update the ReadMe accordingly.
