### PR TITLE
Tiled dirtify

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ In our initial experiments, we used the Sharp subset of the [Blur dataset](https
 ##### dirtify
 To experiment with the Cleanify project, set your working directory to the source folder and run the dirtify tool. Then run the cleanify tool. Here are some examples:
 
-`dirtify --tile --blur 15` (separates source images into tiles, then does a 15-pixel Gaussian blur)</br>  
 `dirtify --jpeg 50` (compresses with JPEG at 50% quality, then decompresses)</br>
-`dirtify --blur 5` (performs a Gaussian blur with a 5-pixel radius)</br>
+`dirtify --blur 15` (performs a Gaussian blur with a 15-pixel radius)</br>
 `dirtify --noise 25` (renders 25% uniform noise on image)</br>
 `dirtify --invert` (inverts the pixels)</br>
 `dirtify --xout` (draws a dark red 1-pixel-wide "X" through the image)</br>
@@ -20,29 +19,35 @@ To experiment with the Cleanify project, set your working directory to the sourc
 The `dirtify` process will create new sibling folders beside raw:
 
 <pre>
-├───cleanify.py
-├───dirtify.py
-└─┬─input
-  ├───raw
-  ├───clean
-  └───dirty
-</pre>
+├────cleanify.py
+├────dirtify.py
+└─┬──input
+  ├────raw
+  ├─┬──clean
+  | ├────tiled ⟸ tiled clean images
+  | └────scaled ⟸ scaled clean images
+  └─┬──dirty
+    ├────tiled ⟸ tiled dirty images
+    └────scaled ⟸ scaled dirty images
+    </pre>
 
 ##### cleanify
 `cleanify` (by default, applies 40 epochs)</br>
 `cleanify --epochs 100` (you can specify a number of epochs)</br>
 `cleanify --autoencoder` (you can use an Autoencoder NN rather than a vanilla CNN)</br>
+`cleanify --tile` (you can either decode the tiled images or the scaled images)</br>
 
 The results will appear in a new output folder.
 <pre>
-├───cleanify.py
-├───dirtify.py
-├─┬─input
-│ ├───raw
-│ ├───clean
-│ └───dirty
-└─┬─output
-  └───saved_images</pre>
+├────cleanify.py
+├────dirtify.py
+├─┬──input
+| ├────raw
+| ├────clean
+| └────dirty
+└─┬──output
+  └────saved_images ⟸ scaled validation results
+</pre>
 
 ### History
 This project was derived from Sovit Ranjan Rath's tutorial, [Image Deblurring using Convolutional Neural Networks and Deep Learning](https://debuggercafe.com/image-deblurring-using-convolutional-neural-networks-and-deep-learning "Tutorial") and his original [GitHub repository](https://github.com/sovit-123/image-deblurring-using-deep-learning "Repo").

--- a/cleanify.py
+++ b/cleanify.py
@@ -21,13 +21,16 @@ from sklearn.model_selection import train_test_split # Split arrays or matrices 
 parser = argparse.ArgumentParser()
 parser.add_argument('-e', '--epochs', type=int, default=40,
             help='number of epochs to train the model for')
-parser.add_argument("-a", "--autoencoder", action="store_true",
-            help="Use an autoencoder NN instead of a vanilla CNN")
+parser.add_argument('-a', '--autoencoder', action='store_true',
+            help='Use an autoencoder NN instead of a vanilla CNN')
+parser.add_argument('-t', '--tile', action='store_true',
+            help='read from the tiled image set instead of the scaled image set')
 # vars returns a _dict_ that is an attribute of the object created by parse_args()
 args = vars(parser.parse_args())
 
 # Make strings for directories
-input_dir  = 'input'
+input_clean_dir  = 'input/clean/tiled' if args['tile'] else 'input/clean/scaled'
+input_dirty_dir  = 'input/dirty/tiled' if args['tile'] else 'input/dirty/scaled'
 output_dir = 'output'
 image_dir  = output_dir + '/saved_images'
 
@@ -42,16 +45,14 @@ print(device)
 # Would be nice to change this name cause it's the same as the arg name
 batch_size = 2
 
-# Make a list of the names of the entries in the 'dirty' directory
-dirty_files = os.listdir(f'{input_dir}/dirty')
-
-# Remove .DS_Store and sort the files
+# Make a list of the names of the entries in the 'clean' and 'dirty' directories
 # For macOS: Skip invisible Desktop Services Store file.
+dirty_files = os.listdir(input_dirty_dir)
 if '.DS_Store' in dirty_files:
     dirty_files.remove('.DS_Store') 
 dirty_files.sort()
 
-clean_files = os.listdir(f'{input_dir}/clean')
+clean_files = os.listdir(input_clean_dir)
 if '.DS_Store' in clean_files:
     clean_files.remove('.DS_Store') # For macOS: Skip invisible Desktop Services Store file.
 clean_files.sort()
@@ -91,13 +92,13 @@ class CleanDataset(Dataset):
         return (len(self.X))
     
     def __getitem__(self, i):
-        dirty_image = cv2.imread(f"{input_dir}/dirty/{self.X[i]}")
+        dirty_image = cv2.imread(f"{input_dirty_dir}/{self.X[i]}")
         
         if self.transforms:
             dirty_image = self.transforms(dirty_image)
             
         if self.y is not None:
-            clean_image = cv2.imread(f"{input_dir}/clean/{self.y[i]}")
+            clean_image = cv2.imread(f"{input_clean_dir}/{self.y[i]}")
             clean_image = self.transforms(clean_image)
             return (dirty_image, clean_image)
         else:

--- a/dirtify.py
+++ b/dirtify.py
@@ -14,8 +14,6 @@ out_h = 64
 
 # construct the argument parser
 parser = argparse.ArgumentParser(description = "Filter a clean image, output a dirty one")
-parser.add_argument("-t", "--tile", action="store_true",
-                    help="use tiles to produce multiple subimages (as opposed to scaling once)")
 parser.add_argument("-j", "--jpeg", type=int,
                     help="JPEG-compress with quality (0-100%) and decompress")
 parser.add_argument("-b", "--blur", type=int,
@@ -46,25 +44,24 @@ if args.noise is not None and (args.noise < 0 or args.noise > 400):
 if abort:
     sys.exit()
 
-# Directories
-# Given a bunch of larger images in the input/raw:
-# (1) scale and crop to a small, square, manageable thumbnail size
-# (2) save that into input/clean
-# (3) add the requested perturbation
-# (4) save that into input/dirty
-
+# Define directories
 clean_dir = 'input/clean'
-shutil.rmtree(clean_dir)
-dirty_dir = 'input/dirty'
-shutil.rmtree(dirty_dir)
-raw_dir = 'input/raw'
-os.makedirs(clean_dir, exist_ok=True)
-os.makedirs(dirty_dir, exist_ok=True)
+clean_tiled_dir = clean_dir + '/tiled'
+os.makedirs(clean_tiled_dir, exist_ok=True)
+shutil.rmtree(clean_tiled_dir)
+clean_scaled_dir = clean_dir + '/scaled'
+os.makedirs(clean_scaled_dir, exist_ok=True)
+shutil.rmtree(clean_scaled_dir)
 
-# Iterate through files in input/raw
-images = os.listdir(raw_dir)
-if '.DS_Store' in images:
-    images.remove('.DS_Store') # For macOS: Skip invisible Desktop Services Store file.
+dirty_dir = 'input/dirty'
+dirty_tiled_dir = dirty_dir + '/tiled'
+os.makedirs(dirty_tiled_dir, exist_ok=True)
+shutil.rmtree(dirty_tiled_dir)
+dirty_scaled_dir = dirty_dir + '/scaled'
+os.makedirs(dirty_scaled_dir, exist_ok=True)
+shutil.rmtree(dirty_scaled_dir)
+
+raw_dir = 'input/raw'
 
 # Dirtify function
 def add_dirt(img):
@@ -125,43 +122,51 @@ def add_dirt(img):
     return img
 
 
-# Step through images
+# Iterate through raw images
+images = os.listdir(raw_dir)
+if '.DS_Store' in images:
+    images.remove('.DS_Store') # For macOS: Skip invisible Desktop Services Store file.
+
 for i, clean in tqdm(enumerate(images), total=len(images)):
     filename = f"{raw_dir}/{images[i]}"
-    img = cv2.imread(filename, cv2.IMREAD_COLOR)
-    in_h, in_w = img.shape[:2]
+    raw_img = cv2.imread(filename, cv2.IMREAD_COLOR)
+    in_h, in_w = raw_img.shape[:2]
+    out_name_base = os.path.splitext(images[i])[0]
     
-    if args.tile:
-        raw_tile_h = 512
-        raw_tile_w = 512
-        for y, x in itertools.product(range(in_h // raw_tile_h), range(in_w // raw_tile_w)):
-            top = y * raw_tile_h
-            bottom = top + raw_tile_h
-            left = x * raw_tile_w
-            right = left + raw_tile_w
-            tile = img[top:bottom, left:right]
-            
-            # Scale from raw tile size to output size
-            scale = out_h / raw_tile_h
-            tile = cv2.resize(tile, None, fx = scale, fy = scale, interpolation = cv2.INTER_AREA)
-            out_name = os.path.splitext(images[i])[0] + f" ({x},{y}).png" # Change the extension to png (for lossless image)
-            cv2.imwrite(f"{clean_dir}/{out_name}", tile)
-            
-            # Add that dirt!
-            img = add_dirt(tile)
-            cv2.imwrite(f"{dirty_dir}/{out_name}", img)
-    else:
-        # resize and crop to make a 64 x 64 image
-        scale = max(out_h / in_h, out_w / in_w)
-        mid_y = scale * in_h / 2
-        mid_x = scale * in_w / 2
-        img = cv2.resize(img, None, fx = scale, fy = scale, interpolation = cv2.INTER_AREA)
-        img = img[round(mid_y - out_h/2):round(mid_y + out_h/2), round(mid_x - out_w/2):round(mid_x + out_w/2)]
-        out_name = os.path.splitext(images[i])[0] + ".png" # Change the extension to png (for lossless image)
-        cv2.imwrite(f"{clean_dir}/{out_name}", img)
+    # First do the scaled set. Resize each raw image and crop to fill a 64 x 64 image
+    scale = max(out_h / in_h, out_w / in_w)
+    mid_y = scale * in_h / 2
+    mid_x = scale * in_w / 2
 
-        # Add that dirt!
-        img = add_dirt(img)
-        cv2.imwrite(f"{dirty_dir}/{out_name}", img)
+    clean_img = cv2.resize(raw_img, None, fx = scale, fy = scale, interpolation = cv2.INTER_AREA)
+    out_img = clean_img[round(mid_y - out_h/2):round(mid_y + out_h/2), round(mid_x - out_w/2):round(mid_x + out_w/2)]
+    out_name = out_name_base + ".png" # Change the extension to png (for lossless image)
+    print (f"Writing {clean_scaled_dir}/{out_name}")
+    cv2.imwrite(f"{clean_scaled_dir}/{out_name}", out_img)
+    # Add that dirt!
+    out_img = add_dirt(out_img)
+    print (f"Writing {dirty_scaled_dir}/{out_name}")
+    cv2.imwrite(f"{dirty_scaled_dir}/{out_name}", out_img)
     
+    # Now do the tiled set: export 2x3 or 3x2 512x512-pixel tiles from each 1536x2048 or 2048x1536 raw image
+    raw_tile_h = 512
+    raw_tile_w = 512
+    for y, x in itertools.product(range(in_h // raw_tile_h), range(in_w // raw_tile_w)):
+        top = y * raw_tile_h
+        bottom = top + raw_tile_h
+        left = x * raw_tile_w
+        right = left + raw_tile_w
+        tile = raw_img[top:bottom, left:right]
+        # Scale from raw tile size to output size
+        scale = out_h / raw_tile_h
+        
+        tile = cv2.resize(tile, None, fx = scale, fy = scale, interpolation = cv2.INTER_AREA)
+        out_name = out_name_base + f" ({x},{y}).png" # Change the extension to png (for lossless image)
+        print (f"Writing {clean_tiled_dir}/{out_name}")
+        cv2.imwrite(f"{clean_tiled_dir}/{out_name}", tile)
+        # Add that dirt!
+        out_img = add_dirt(tile)
+        print (f"Writing {dirty_tiled_dir}/{out_name}")
+        cv2.imwrite(f"{dirty_tiled_dir}/{out_name}", out_img)
+
 print('DONE')

--- a/dirtify.py
+++ b/dirtify.py
@@ -141,11 +141,9 @@ for i, clean in tqdm(enumerate(images), total=len(images)):
     clean_img = cv2.resize(raw_img, None, fx = scale, fy = scale, interpolation = cv2.INTER_AREA)
     out_img = clean_img[round(mid_y - out_h/2):round(mid_y + out_h/2), round(mid_x - out_w/2):round(mid_x + out_w/2)]
     out_name = out_name_base + ".png" # Change the extension to png (for lossless image)
-    print (f"Writing {clean_scaled_dir}/{out_name}")
     cv2.imwrite(f"{clean_scaled_dir}/{out_name}", out_img)
     # Add that dirt!
     out_img = add_dirt(out_img)
-    print (f"Writing {dirty_scaled_dir}/{out_name}")
     cv2.imwrite(f"{dirty_scaled_dir}/{out_name}", out_img)
     
     # Now do the tiled set: export 2x3 or 3x2 512x512-pixel tiles from each 1536x2048 or 2048x1536 raw image
@@ -162,11 +160,9 @@ for i, clean in tqdm(enumerate(images), total=len(images)):
         
         tile = cv2.resize(tile, None, fx = scale, fy = scale, interpolation = cv2.INTER_AREA)
         out_name = out_name_base + f" ({x},{y}).png" # Change the extension to png (for lossless image)
-        print (f"Writing {clean_tiled_dir}/{out_name}")
         cv2.imwrite(f"{clean_tiled_dir}/{out_name}", tile)
         # Add that dirt!
         out_img = add_dirt(tile)
-        print (f"Writing {dirty_tiled_dir}/{out_name}")
         cv2.imwrite(f"{dirty_tiled_dir}/{out_name}", out_img)
 
 print('DONE')

--- a/dirtify.py
+++ b/dirtify.py
@@ -47,18 +47,18 @@ if abort:
 # Define directories
 clean_dir = 'input/clean'
 clean_tiled_dir = clean_dir + '/tiled'
-shutil.rmtree(clean_tiled_dir)
+shutil.rmtree(clean_tiled_dir, ignore_errors=True)
 os.makedirs(clean_tiled_dir, exist_ok=True)
 clean_scaled_dir = clean_dir + '/scaled'
-shutil.rmtree(clean_scaled_dir)
+shutil.rmtree(clean_scaled_dir, ignore_errors=True)
 os.makedirs(clean_scaled_dir, exist_ok=True)
 
 dirty_dir = 'input/dirty'
 dirty_tiled_dir = dirty_dir + '/tiled'
-shutil.rmtree(dirty_tiled_dir)
+shutil.rmtree(dirty_tiled_dir, ignore_errors=True)
 os.makedirs(dirty_tiled_dir, exist_ok=True)
 dirty_scaled_dir = dirty_dir + '/scaled'
-shutil.rmtree(dirty_scaled_dir)
+shutil.rmtree(dirty_scaled_dir, ignore_errors=True)
 os.makedirs(dirty_scaled_dir, exist_ok=True)
 
 raw_dir = 'input/raw'

--- a/dirtify.py
+++ b/dirtify.py
@@ -47,19 +47,19 @@ if abort:
 # Define directories
 clean_dir = 'input/clean'
 clean_tiled_dir = clean_dir + '/tiled'
-os.makedirs(clean_tiled_dir, exist_ok=True)
 shutil.rmtree(clean_tiled_dir)
+os.makedirs(clean_tiled_dir, exist_ok=True)
 clean_scaled_dir = clean_dir + '/scaled'
-os.makedirs(clean_scaled_dir, exist_ok=True)
 shutil.rmtree(clean_scaled_dir)
+os.makedirs(clean_scaled_dir, exist_ok=True)
 
 dirty_dir = 'input/dirty'
 dirty_tiled_dir = dirty_dir + '/tiled'
-os.makedirs(dirty_tiled_dir, exist_ok=True)
 shutil.rmtree(dirty_tiled_dir)
+os.makedirs(dirty_tiled_dir, exist_ok=True)
 dirty_scaled_dir = dirty_dir + '/scaled'
-os.makedirs(dirty_scaled_dir, exist_ok=True)
 shutil.rmtree(dirty_scaled_dir)
+os.makedirs(dirty_scaled_dir, exist_ok=True)
 
 raw_dir = 'input/raw'
 


### PR DESCRIPTION
Added support for tiling. Now `dirtify` always creates these folders:

- `input/clean/tiled`
- `input/clean/scaled`
- `input/dirty/tiled`
- `input/dirty/scaled`

Removed the `--tile` option from `dirtify`. Now `cleanify` takes a `--tile` option, telling it whether to process from the tiled folders or the scaled folders.